### PR TITLE
Reshuffles Ranger gear, adds alt title

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -20,11 +20,9 @@
 
 /decl/hierarchy/outfit/job/security/hos
 	name = OUTFIT_JOB_NAME("Chief of Police")
-	/obj/item/clothing/head/police/rangerchiefhat
+	head = /obj/item/clothing/head/police/policechiefcap
 	l_ear = /obj/item/device/radio/headset/heads/hos
-	glasses = /obj/item/clothing/glasses/sunglasses/goldaviators
-	uniform = /obj/item/clothing/under/rank/rangerchief
-	suit = /obj/item/clothing/suit/security/chiefcoat
+	uniform = /obj/item/clothing/under/rank/policechiefalt
 	id_type = /obj/item/weapon/card/id/security/head
 	pda_type = /obj/item/device/pda/heads/hos
 	backpack_contents = list(/obj/item/weapon/handcuffs = 1,
@@ -68,6 +66,14 @@
 
 /decl/hierarchy/outfit/job/security/officer
 	name = OUTFIT_JOB_NAME("Police Officer")
+	head = /obj/item/clothing/head/police/policeofficercap
+	uniform = /obj/item/clothing/under/rank/policeofficeralt
+	l_pocket = /obj/item/device/flash
+	id_type = /obj/item/weapon/card/id/security/officer
+	pda_type = /obj/item/device/pda/security
+
+/decl/hierarchy/outfit/job/security/ranger
+	name = OUTFIT_JOB_NAME("Police Ranger")
 	head = /obj/item/clothing/head/police/rangerofficer
 	uniform = /obj/item/clothing/under/rank/rangerofficer
 	glasses = /obj/item/clothing/glasses/fakesunglasses/ranger

--- a/code/game/jobs/job/police.dm
+++ b/code/game/jobs/job/police.dm
@@ -130,7 +130,7 @@
 	minimum_character_age = 23
 
 	outfit_type = /decl/hierarchy/outfit/job/security/officer
-	alt_titles = list("Police Cadet" = /decl/hierarchy/outfit/job/security/cadet,"Traffic Officer" = /decl/hierarchy/outfit/job/security/traffic)
+	alt_titles = list("Police Cadet" = /decl/hierarchy/outfit/job/security/cadet,"Traffic Officer" = /decl/hierarchy/outfit/job/security/traffic,"Police Ranger" = /decl/hierarchy/outfit/job/security/ranger)
 
 	clean_record_required = TRUE
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -138,6 +138,10 @@
 		new /obj/item/clothing/shoes/boots/winter/security(src)
 		new /obj/item/device/flashlight/maglight(src)
 		new /obj/item/weapon/stamp/hos(src)
+		new /obj/item/clothing/head/police/rangerchiefhat(src)
+		new /obj/item/clothing/under/rank/rangerchief(src)
+		new /obj/item/clothing/suit/security/chiefcoat(src)
+		new /obj/item/clothing/glasses/sunglasses/goldaviators(src)
 		return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added a Police Ranger alt title, restores old officer loadout, moves the ranger gear to the alt title.
Restores old police chief gear, moves the ranger gear to the police chief locker.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having rangers be the default uniform in a capital city is a bit strange. This isn't a fork of National Parks SS13.
Moving the gear to an alt-title makes it actual player self-expression that I think was wanted in the first place, rather than everyone wearing it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Police Ranger alt-title
tweak: Restored the default police uniform in their loadout.
tweak: Moved the Chief of Police ranger uniform to their locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->