### PR TITLE
adds airlock deny sound

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -820,6 +820,7 @@ About the new airlock wires panel:
 			if(lights && src.arePowerSystemsOn())
 				lights_overlay = deny_file
 				set_light(0.25, 0.1, 1, 2, COLOR_RED_LIGHT)
+				playsound(src.loc, denied_sound, 50, 0)
 
 		if(AIRLOCK_EMAG)
 			sparks_overlay = emag_file


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the deny sound for when you cant go through a airlock, cause why the fuck isnt it there.

## Why It's Good For The Game

Sound.

## Changelog
:cl:
fix: airlock now has deny sound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->