### PR TITLE
Expanded website size

### DIFF
--- a/code/modules/modular_computers/file_system/websites/website_creator.dm
+++ b/code/modules/modular_computers/file_system/websites/website_creator.dm
@@ -4,7 +4,7 @@
 	path = "websites/sitemaker.txt"
 	var/max_websites = 40 //To avoid killing the game.
 	var/name_length_limit = 50 //Massivelongurltotryandcrashpoorcassieserver.co.uk
-	var/max_html_limit = 500 //Change this as you see fit. This is to stop Rshoe from uploading 40 websites with 20,000 lines of POGCHAMP.jpg.
+	var/max_html_limit = 5000 //Change this as you see fit. This is to stop Rshoe from uploading 40 websites with 20,000 lines of POGCHAMP.jpg.
 
 /datum/website/creator/on_access(user)
 	if(GLOB.websites.len >= max_websites)
@@ -30,7 +30,7 @@
 	new_title = sanitize(toname) //let's try to not link your admins to pornhub everytime someone makes a site.
 
 	if(length(new_content) >= max_html_limit) //piss off RSHOE
-		to_chat(user, "You are limited to [max_html_limit] lines of HTML per website on your company's plan. Please try again.")
+		to_chat(user, "You are limited to [max_html_limit] characters of HTML per website on your company's plan. Please try again.")
 		return
 	//Now we're going to do some basic sanitization so you (hopefully) can't just link to an actual virus.
 	new_content = replacetext(new_content, "https://", "{LINK EXPUNGED}")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

500 characters of html is an absolutely pitiful amount. I couldn't even write my website as plain unformatted text with so little - and it's not a big website!
So, this expands the character limit tenfold, to a maximum of 5,000 characters, which should be more than enough.

Also fixes a typo where it would incorrectly tell you that you wrote too many lines, rather than too many characters.

## Why It's Good For The Game

Funny in-universe websites! Make those sites look like they crawled out of hypnospace outlaw and into byond!

## Changelog
:cl:
tweak: NTNet websites can now use up to 5,000 characters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->