### PR TITLE
Reenables Hyperzine

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -402,15 +402,14 @@
 	required_reagents = list("bicaridine" = 1, "iron" = 2, "spidertoxin" = 1)
 	result_amount = 2
 
-//Removed due to aboose.
-/*
+
 /datum/chemical_reaction/hyperzine
 	name = "Hyperzine"
 	id = "hyperzine"
 	result = "hyperzine"
 	required_reagents = list("sugar" = 1, "phosphorus" = 1, "sulfur" = 1)
 	result_amount = 3
-*/
+
 /datum/chemical_reaction/stimm
 	name = "Stimm"
 	id = "stimm"


### PR DESCRIPTION
## About The Pull Request

This reenables the speedy chem Hyperzine.

## Why It's Good For The Game

![cooltext430041056529703](https://user-images.githubusercontent.com/98407398/220231837-c6011174-8bea-4778-98f4-dda3c0db5478.gif)


## Changelog
:cl:
tweak: removed some lines of code that disabled the hyperzine recipe, meaning that hyperzine is now createable
/:cl: