### PR TITLE
Seed Storage Persistence

### DIFF
--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -139,6 +139,10 @@
 		return
 
 	if (!seeds_initialized)
+		// shiptest change: contents save, but their datums don't, so we need use te add proc to make the machine remember those exist
+		for(var/O in contents)
+			add(O)
+		// end
 		for(var/typepath in starting_seeds)
 			var/amount = starting_seeds[typepath]
 			if(isnull(amount)) amount = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Seed storage has been keeping seeds from previous rounds this whole time - they just didn't show up in the interface. Now those those seeds are visible.

## Why It's Good For The Game

Botany should probably be able to keep their seeds

## Changelog
:cl:
fix: seed storage now shows you seeds from previous rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->